### PR TITLE
Use 'plasma-utils' for txgen and proof checking

### DIFF
--- a/src/block-manager/leveldb-sum-tree.js
+++ b/src/block-manager/leveldb-sum-tree.js
@@ -224,7 +224,7 @@ class LevelDBSumTree {
         leftChild = null
       }).on('end', async () => {
         // Check if there was only one node--that means we hit the root
-        if (parentIndex.eq(new BN(1))) {
+        if (numChildren.eq(new BN(2))) {
           log('Returning root hash:', Buffer.from(parentNode.hash).toString('hex'))
           await self.writeNumLevels(blockNumber, parentLevel)
           resolve(parentNode.hash)


### PR DESCRIPTION
Updated the operator test code to use master `plasma-utils` for dummy generation, and added double checks for parity between `TransferProof` and `TransactionProof` checking between both the contract and the `PlasmaMerkleSumTree` checker from utils.