### PR TITLE
Bugfix present

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 - `g++` -- version 7.3.1
 
 
-$ npm install plasma-chain -g
-$ operator account new
-$ operator init
-$ operator start
+$ npm install
+$ ./bin/plasma-chain.js new
+$ ./bin/plasma-chain.js init
+$ ./bin/plasma-chain.js operator start
 
 To deploy a new Plasma Chain, use the following commands:
 ```

--- a/bin/plasma-chain-account.js
+++ b/bin/plasma-chain-account.js
@@ -8,11 +8,11 @@ const { appRootPath } = require('../src/utils')
 const Web3 = require('web3')
 const KEYSTORE_DIR = require('../src/constants.js').KEYSTORE_DIR
 
-const web3 = new Web3()
+const web3 = new Web3();
 
 (async () => {
 
-  const appRoot = appRootPath();
+  const appRoot = await appRootPath();
   const keystoreDirectory = path.join(appRoot, KEYSTORE_DIR);
 
   program

--- a/bin/plasma-chain-account.js
+++ b/bin/plasma-chain-account.js
@@ -4,87 +4,97 @@ const path = require('path')
 const program = require('commander')
 const colors = require('colors') // eslint-disable-line no-unused-vars
 const inquirer = require('inquirer')
-const appRoot = require('app-root-path')
+const { appRootPath } = require('../src/utils')
 const Web3 = require('web3')
 const KEYSTORE_DIR = require('../src/constants.js').KEYSTORE_DIR
 
 const web3 = new Web3()
-const keystoreDirectory = path.join(appRoot.toString(), KEYSTORE_DIR)
 
-program
-  .command('new')
-  .description('creates a new account')
-  .option('-p, --plaintext', 'Store the private key in plaintext')
-  .action(async (none, cmd) => {
-    if (!fs.existsSync(keystoreDirectory)) {
-      fs.mkdirSync(keystoreDirectory)
-    }
-    // Check that there are no accounts already -- no reason to have more than one operator account
-    const accounts = fs.readdirSync(keystoreDirectory)
-    if (accounts.length) {
-      console.log('Account already created! Try starting the operator with `operator start`')
-      return
-    }
-    // There are no accounts so create one!
-    const newAccount = await createAccount(cmd.plaintext)
-    if (newAccount === undefined) {
-      return
-    }
-    console.log('Created new account with address:', newAccount.address.green)
-    const keystorePath = path.join(keystoreDirectory, new Date().toISOString() + '--' + newAccount.address)
-    console.log('Saving encrypted account to:', keystorePath.yellow)
-    fs.writeFileSync(keystorePath, newAccount.keystoreFile)
-    // Create new password file
-  })
+(async () => {
 
-program
-  .command('list')
-  .description('list all accounts')
-  .action((none, cmd) => {
-    let counter = 0
-    if (!fs.existsSync(keystoreDirectory)) {
-      console.log('No accounts found!')
-      return
-    }
-    fs.readdirSync(keystoreDirectory).forEach(file => {
-      console.log('Account #' + counter++ + ':', file.split('--')[1])
+  const appRoot = appRootPath();
+  const keystoreDirectory = path.join(appRoot, KEYSTORE_DIR);
+
+  program
+    .command('new')
+    .description('creates a new account')
+    .option('-p, --plaintext', 'Store the private key in plaintext')
+    .action(async (none, cmd) => {
+      if (!fs.existsSync(keystoreDirectory)) {
+        fs.mkdirSync(keystoreDirectory)
+      }
+      // Check that there are no accounts already -- no reason to have more than one operator account
+      const accounts = fs.readdirSync(keystoreDirectory)
+      if (accounts.length) {
+        console.log('Account already created! Try starting the operator with `operator start`')
+        return
+      }
+      // There are no accounts so create one!
+      const newAccount = await createAccount(cmd.plaintext)
+      if (newAccount === undefined) {
+        return
+      }
+      console.log('Created new account with address:', newAccount.address.green)
+      const keystorePath = path.join(keystoreDirectory, new Date().toISOString() + '--' + newAccount.address)
+      console.log('Saving encrypted account to:', keystorePath.yellow)
+      fs.writeFileSync(keystorePath, newAccount.keystoreFile)
+      // Create new password file
     })
-  })
 
-async function createAccount (isPlaintext) {
-  if (isPlaintext) {
+  program
+    .command('list')
+    .description('list all accounts')
+    .action((none, cmd) => {
+      let counter = 0
+      if (!fs.existsSync(keystoreDirectory)) {
+        console.log('No accounts found!')
+        return
+      }
+      fs.readdirSync(keystoreDirectory).forEach(file => {
+        console.log('Account #' + counter++ + ':', file.split('--')[1])
+      })
+    })
+
+  async function createAccount (isPlaintext) {
+    if (isPlaintext) {
+      const newAccount = web3.eth.accounts.create()
+      return {
+        address: newAccount.address,
+        keystoreFile: JSON.stringify(newAccount)
+      }
+    }
+    // If it's not plaintext, we need to prompt for password
+    console.log('Your new account is locked with a password. Please give a password. Do not forget this password.')
+    const response = await inquirer.prompt([{
+      type: 'password',
+      name: 'password',
+      message: 'Passphrase:'
+    },
+    {
+      type: 'password',
+      name: 'retypePassword',
+      message: 'Repeat passphrase:'
+    }])
+    if (response.password !== response.retypePassword) {
+      console.log('Passwords do not match! Try again...'.red)
+      return
+    }
     const newAccount = web3.eth.accounts.create()
+    const encryptedAccount = newAccount.encrypt(response.password)
     return {
       address: newAccount.address,
-      keystoreFile: JSON.stringify(newAccount)
+      keystoreFile: JSON.stringify(encryptedAccount)
     }
   }
-  // If it's not plaintext, we need to prompt for password
-  console.log('Your new account is locked with a password. Please give a password. Do not forget this password.')
-  const response = await inquirer.prompt([{
-    type: 'password',
-    name: 'password',
-    message: 'Passphrase:'
-  },
-  {
-    type: 'password',
-    name: 'retypePassword',
-    message: 'Repeat passphrase:'
-  }])
-  if (response.password !== response.retypePassword) {
-    console.log('Passwords do not match! Try again...'.red)
-    return
-  }
-  const newAccount = web3.eth.accounts.create()
-  const encryptedAccount = newAccount.encrypt(response.password)
-  return {
-    address: newAccount.address,
-    keystoreFile: JSON.stringify(encryptedAccount)
-  }
-}
 
-program.parse(process.argv)
+  program.parse(process.argv)
 
-if (program.args.length === 1) {
-  console.log('Command not found. Try `' + 'operator help account'.yellow + '` for more options')
-}
+  if (program.args.length === 1) {
+    console.log('Command not found. Try `' + 'operator help account'.yellow + '` for more options')
+  }
+
+})().catch(e => {
+  console.error(e)
+  process.exit(1);
+});
+

--- a/bin/plasma-chain-init.js
+++ b/bin/plasma-chain-init.js
@@ -5,72 +5,78 @@ const colors = require('colors') // eslint-disable-line no-unused-vars
 const inquirer = require('inquirer')
 const getAccount = require('./utils.js').getAccount
 const ethService = require('../src/eth-service.js')
-const readConfigFile = require('../src/utils.js').readConfigFile
+const readConfigFile = require('../src/utils.js').readConfigFile;
 
-program
-  .description('starts the operator using the first account')
-  .option('-n, --newRegistry', 'Initialize a new Plasma Network in addition to a Plasma Chain')
-  .action(async (none, cmd) => {
-    const account = await getAccount()
-    if (account === null) {
-      return
-    }
-    // Get the config
-    const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(__dirname, '..', 'config.json')
-    console.log('Reading config file from:', configFile)
-    const config = readConfigFile(configFile)
-    // Ask for a Plasma Chain name and ip address
-    const chainMetadata = await setChainMetadata(config)
-    console.log('Chain metadata:', chainMetadata)
-    // Add the chain metadata to the config
-    config.plasmaChainName = chainMetadata.chainName
-    config.operatorIpAddress = chainMetadata.ipAddress
-    // Initialize a new Plasma Chain
-    config.privateKey = account.privateKey
-    if (cmd.newRegistry === true) {
-      config.plasmaRegistryAddress = 'DEPLOY'
-    }
-    await ethService.startup(config)
-  })
-
-async function setChainMetadata (config) {
-  console.log('\n~~~~~~~~~plasma~~~~~~~~~chain~~~~~~~~~initialization~~~~~~~~~'.rainbow)
-  console.log("\nBefore we deploy your new Plasma Chain, I'll need to ask a couple questions.".white)
-  const plasmaChainMetadata = {}
-  // Get the Plasma Chain name
-  const chainName = await getPlasmaChainName(config)
-  Object.assign(plasmaChainMetadata, chainName)
-  // Set the hostname
-  console.log('\nWhat is your IP address? Or a domain name that points to your IP.\n'.white, 'WARNING:'.yellow, 'This IP address will be posted to the Ethereum blockchain.'.white)
-  const hostResponse = await inquirer.prompt([{
-    type: 'input',
-    name: 'ipAddress',
-    default: (config.operatorIpAddress === undefined) ? '' : config.operatorIpAddress,
-    message: 'Your IP address or hostname:'
-  }])
-  Object.assign(plasmaChainMetadata, hostResponse)
-  return plasmaChainMetadata
-}
-
-async function getPlasmaChainName (config) {
-  console.log('\nWhat is the name of your new Plasma Chain?\nThis will be displayed in the'.white, 'Plasma Network Explorer'.green, '--'.white, 'http://plasma.run'.blue)
-  const chainNameResponse = await inquirer.prompt([{
-    type: 'input',
-    name: 'chainName',
-    message: "Your Plasma Chain's Name:",
-    default: (config.plasmaChainName === undefined) ? '' : config.plasmaChainName,
-    validate: (input) => {
-      if (input.length < 3) {
-        console.log('Error!'.red, 'Plasma Chain Name is too short!')
-        return false
-      } else if (Buffer.from(input, 'utf8').length > 32) {
-        console.log('Error!'.red, 'Plasma Chain Name is too long!')
-        return false
+(async () => {
+  program
+    .description('starts the operator using the first account')
+    .option('-n, --newRegistry', 'Initialize a new Plasma Network in addition to a Plasma Chain')
+    .action(async (none, cmd) => {
+      const account = await getAccount()
+      if (account === null) {
+        return
       }
-      return true
-    }
-  }])
-  return chainNameResponse
-}
+      // Get the config
+      const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(__dirname, '..', 'config.json')
+      console.log('Reading config file from:', configFile)
+      const config = await readConfigFile(configFile)
+      // Ask for a Plasma Chain name and ip address
+      const chainMetadata = await setChainMetadata(config)
+      console.log('Chain metadata:', chainMetadata)
+      // Add the chain metadata to the config
+      config.plasmaChainName = chainMetadata.chainName
+      config.operatorIpAddress = chainMetadata.ipAddress
+      // Initialize a new Plasma Chain
+      config.privateKey = account.privateKey
+      if (cmd.newRegistry === true) {
+        config.plasmaRegistryAddress = 'DEPLOY'
+      }
+      await ethService.startup(config)
+    })
 
-program.parse(process.argv)
+  async function setChainMetadata (config) {
+    console.log('\n~~~~~~~~~plasma~~~~~~~~~chain~~~~~~~~~initialization~~~~~~~~~'.rainbow)
+    console.log("\nBefore we deploy your new Plasma Chain, I'll need to ask a couple questions.".white)
+    const plasmaChainMetadata = {}
+    // Get the Plasma Chain name
+    const chainName = await getPlasmaChainName(config)
+    Object.assign(plasmaChainMetadata, chainName)
+    // Set the hostname
+    console.log('\nWhat is your IP address? Or a domain name that points to your IP.\n'.white, 'WARNING:'.yellow, 'This IP address will be posted to the Ethereum blockchain.'.white)
+    const hostResponse = await inquirer.prompt([{
+      type: 'input',
+      name: 'ipAddress',
+      default: (config.operatorIpAddress === undefined) ? '' : config.operatorIpAddress,
+      message: 'Your IP address or hostname:'
+    }])
+    Object.assign(plasmaChainMetadata, hostResponse)
+    return plasmaChainMetadata
+  }
+
+  async function getPlasmaChainName (config) {
+    console.log('\nWhat is the name of your new Plasma Chain?\nThis will be displayed in the'.white, 'Plasma Network Explorer'.green, '--'.white, 'http://plasma.run'.blue)
+    const chainNameResponse = await inquirer.prompt([{
+      type: 'input',
+      name: 'chainName',
+      message: "Your Plasma Chain's Name:",
+      default: (config.plasmaChainName === undefined) ? '' : config.plasmaChainName,
+      validate: (input) => {
+        if (input.length < 3) {
+          console.log('Error!'.red, 'Plasma Chain Name is too short!')
+          return false
+        } else if (Buffer.from(input, 'utf8').length > 32) {
+          console.log('Error!'.red, 'Plasma Chain Name is too long!')
+          return false
+        }
+        return true
+      }
+    }])
+    return chainNameResponse
+  }
+
+  program.parse(process.argv)
+
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/bin/plasma-chain-init.js
+++ b/bin/plasma-chain-init.js
@@ -4,7 +4,7 @@ const program = require('commander')
 const colors = require('colors') // eslint-disable-line no-unused-vars
 const inquirer = require('inquirer')
 const getAccount = require('./utils.js').getAccount
-const ethService = require('../src/eth-service.js')
+const ethService = require('../src/eth-service.js');
 const readConfigFile = require('../src/utils.js').readConfigFile;
 
 (async () => {

--- a/bin/plasma-chain-start.js
+++ b/bin/plasma-chain-start.js
@@ -2,24 +2,35 @@
 const path = require('path')
 const program = require('commander')
 const colors = require('colors') // eslint-disable-line no-unused-vars
-const appRoot = require('app-root-path')
-const getAccount = require('./utils.js').getAccount
-const server = require(appRoot + '/src/server.js')
-const readConfigFile = require(appRoot + '/src/utils.js').readConfigFile
+const { getAccount, appRootPath } = require('./utils.js');
+const utils = require('./utils.js');
 
-program
-  .command('*')
-  .description('starts the operator using the first account')
-  .action(async (none, cmd) => {
-    const account = await getAccount()
-    if (account === null) {
-      return
-    }
-    // Start the server!
-    const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(appRoot.toString(), 'config.json')
-    const config = readConfigFile(configFile)
-    config.privateKey = account.privateKey
-    await server.startup(config)
-  })
+(async () => {
 
-program.parse(process.argv)
+  const appRoot = await appRootPath();
+
+  const server = require(appRoot + '/src/server.js')
+  const readConfigFile = require(appRoot + '/src/utils.js').readConfigFile
+
+  program
+    .command('*')
+    .description('starts the operator using the first account')
+    .action(async (none, cmd) => {
+      const account = await getAccount()
+      if (account === null) {
+        return
+      }
+      // Start the server!
+      const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(appRoot, 'config.json')
+      const config = await readConfigFile(configFile)
+      config.privateKey = account.privateKey
+      await server.startup(config)
+    })
+
+  program.parse(process.argv)
+
+})().catch(e => {
+  console.error(e)
+  process.exit(1)
+})
+

--- a/bin/plasma-chain-testSwarm.js
+++ b/bin/plasma-chain-testSwarm.js
@@ -2,105 +2,115 @@
 const path = require('path')
 const program = require('commander')
 const colors = require('colors') // eslint-disable-line no-unused-vars
-const appRoot = require('app-root-path')
 const constants = require('../src/constants.js')
 const UnsignedTransaction = require('plasma-utils').serialization.models.UnsignedTransaction
 const Web3 = require('web3')
 const BN = require('web3').utils.BN
-const readConfigFile = require(appRoot + '/src/utils.js').readConfigFile
 const axios = require('axios')
 const accounts = require('../test/mock-accounts.js').accounts
 const MockNode = require('../src/mock-node.js')
+const { appRootPath } = require('../src/utils');
 
-const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
+const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-// Get the config
-const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(appRoot.toString(), 'config.json')
-const config = readConfigFile(configFile)
-const http = axios.create({
-  baseURL: 'http://localhost:' + config.port
-})
+(async () => {
 
-let idCounter
-let totalDeposits = {}
+  const appRoot = await appRootPath();
+  const readConfigFile = require(appRoot + '/src/utils.js').readConfigFile
 
-// Operator object wrapper to query api
-const operator = {
-  addTransaction: async (tx) => {
-    const encodedTx = tx.encoded
-    let txResponse
-    txResponse = await http.post('/api', {
-      method: constants.ADD_TX_METHOD,
-      jsonrpc: '2.0',
-      id: idCounter++,
-      params: [
-        encodedTx
-      ]
-    })
-    return txResponse.data
-  },
-  addDeposit: async (recipient, token, amount) => {
-    // First calculate start and end from token amount
-    const tokenTypeKey = token.toString()
-    if (totalDeposits[tokenTypeKey] === undefined) {
-      totalDeposits[tokenTypeKey] = new BN(0)
-    }
-    const start = new BN(totalDeposits[tokenTypeKey])
-    totalDeposits[tokenTypeKey] = new BN(totalDeposits[tokenTypeKey].add(amount))
-    const end = new BN(totalDeposits[tokenTypeKey])
-    let txResponse
-    txResponse = await http.post('/api', {
-      method: constants.DEPOSIT_METHOD,
-      jsonrpc: '2.0',
-      id: idCounter++,
-      params: {
-        recipient: Web3.utils.bytesToHex(recipient),
-        token: token.toString(16),
-        start: start.toString(16),
-        end: end.toString(16)
-      }
-    })
-    return new UnsignedTransaction(txResponse.data.deposit)
-  },
-  getBlockNumber: async () => {
-    const response = await http.post('/api', {
-      method: constants.GET_BLOCK_NUMBER_METHOD,
-      jsonrpc: '2.0',
-      id: idCounter++,
-      params: []
-    })
-    console.log('Sending transactions for block:', new BN(response.data.result, 10).toString(10).green)
-    return new BN(response.data.result, 10)
-  }
-}
-
-program
-  .command('*')
-  .description('starts a swarm of test nodes for load testing')
-  .action(async (none, cmd) => {
-    const nodes = []
-    for (const acct of accounts) {
-      nodes.push(new MockNode(operator, acct, nodes))
-    }
-    // Add deposits -- it will be a random token above token type 1000 to avoid overlap with real deposits...
-    const depositType = new BN(999 + Math.floor(Math.random() * 10000))
-    const depositAmount = new BN(10000000, 'hex')
-    for (const node of nodes) {
-      await node.deposit(depositType, depositAmount)
-    }
-    const startTime = +new Date()
-    // Transact on a looonng loooop!
-    for (let i = 0; i < 100000; i++) {
-      // Get the current block number
-      const blockNumber = await operator.getBlockNumber()
-      const promises = []
-      for (const node of nodes) {
-        promises.push(node.sendRandomTransaction(blockNumber, 2, true))
-      }
-      await Promise.all(promises)
-      timeout(100)
-    }
-    console.log('Total time:', +new Date() - startTime)
+  // Get the config
+  const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(appRoot, 'config.json')
+  const config = await readConfigFile(configFile)
+  const http = axios.create({
+    baseURL: 'http://localhost:' + config.port
   })
 
-program.parse(process.argv)
+  let idCounter
+  let totalDeposits = {}
+
+  // Operator object wrapper to query api
+  const operator = {
+    addTransaction: async (tx) => {
+      const encodedTx = tx.encoded
+      let txResponse
+      txResponse = await http.post('/api', {
+        method: constants.ADD_TX_METHOD,
+        jsonrpc: '2.0',
+        id: idCounter++,
+        params: [
+          encodedTx
+        ]
+      })
+      return txResponse.data
+    },
+    addDeposit: async (recipient, token, amount) => {
+      // First calculate start and end from token amount
+      const tokenTypeKey = token.toString()
+      if (totalDeposits[tokenTypeKey] === undefined) {
+        totalDeposits[tokenTypeKey] = new BN(0)
+      }
+      const start = new BN(totalDeposits[tokenTypeKey])
+      totalDeposits[tokenTypeKey] = new BN(totalDeposits[tokenTypeKey].add(amount))
+      const end = new BN(totalDeposits[tokenTypeKey])
+      let txResponse
+      txResponse = await http.post('/api', {
+        method: constants.DEPOSIT_METHOD,
+        jsonrpc: '2.0',
+        id: idCounter++,
+        params: {
+          recipient: Web3.utils.bytesToHex(recipient),
+          token: token.toString(16),
+          start: start.toString(16),
+          end: end.toString(16)
+        }
+      })
+      return new UnsignedTransaction(txResponse.data.deposit)
+    },
+    getBlockNumber: async () => {
+      const response = await http.post('/api', {
+        method: constants.GET_BLOCK_NUMBER_METHOD,
+        jsonrpc: '2.0',
+        id: idCounter++,
+        params: []
+      })
+      console.log('Sending transactions for block:', new BN(response.data.result, 10).toString(10).green)
+      return new BN(response.data.result, 10)
+    }
+  }
+
+  program
+    .command('*')
+    .description('starts a swarm of test nodes for load testing')
+    .action(async (none, cmd) => {
+      const nodes = []
+      for (const acct of accounts) {
+        nodes.push(new MockNode(operator, acct, nodes))
+      }
+      // Add deposits -- it will be a random token above token type 1000 to avoid overlap with real deposits...
+      const depositType = new BN(999 + Math.floor(Math.random() * 10000))
+      const depositAmount = new BN(10000000, 'hex')
+      for (const node of nodes) {
+        await node.deposit(depositType, depositAmount)
+      }
+      const startTime = +new Date()
+      // Transact on a looonng loooop!
+      for (let i = 0; i < 100000; i++) {
+        // Get the current block number
+        const blockNumber = await operator.getBlockNumber()
+        const promises = []
+        for (const node of nodes) {
+          promises.push(node.sendRandomTransaction(blockNumber, 2, true))
+        }
+        await Promise.all(promises)
+        timeout(100)
+      }
+      console.log('Total time:', +new Date() - startTime)
+    })
+
+  program.parse(process.argv)
+
+})().catch(e => {
+  console.error(e)
+  process.exit(1);
+})
+

--- a/bin/plasma-chain.js
+++ b/bin/plasma-chain.js
@@ -1,60 +1,67 @@
 #!/usr/bin/env node
+
 const program = require('commander')
 const colors = require('colors') // eslint-disable-line no-unused-vars
-const appRoot = require('app-root-path')
-const readConfigFile = require('../src/utils.js').readConfigFile
-const path = require('path')
+const { readConfigFile, appRootPath } = require('../src/utils.js');
+const path = require('path');
 
-const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(appRoot.toString(), 'config.json')
-const config = readConfigFile(configFile)
-const isRinkeby = config.web3HttpProvider.includes('rinkeby')
+(async () => {
 
-const rinkebyStep2 = `# On Rinkeby testnet, send your new Operator address ~0.5 ETH.
-You can use a faucet to get test ETH for free here: ${'https://faucet.rinkeby.io/'.green}`
-const rinkebyStep3 = `${'$ plasma-chain deploy'.green} # initalizes a new Plasma Chain.
-Note you will be prompted for a unique Plasma Chain name & IP address.
-If you are running on your laptop, just set the IP to \`0.0.0.0\` as you probably don't
-want to reveal your IP to the public. However, if you are running in a data center and would
-like to accept Plasma transactions & serve a block explorer to the public, go ahead and set an IP.`
-const customStep2 = '# On your Ethereum node, send your new Operator address ~0.5 ETH'
-const customStep3 = `${'$ plasma-chain deploy [-n]'.green} # deploys a new Plasma Chain. If you want
-to also deploy a new Plasma Network Registry, use the \`-n\` flag. Note you will be prompted for a unique
-Plasma Chain name & IP address (public to the Ethereum chain you deploy to)`
+  const appRoot = await appRootPath();
+  const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(appRoot, 'config.json')
+  const config = await readConfigFile(configFile)
+  const isRinkeby = config.web3HttpProvider.includes('rinkeby')
 
-const introText = `
-${'~~~~~~~~~plasma~~~~~~~~~chain~~~~~~~~~operator~~~~~~~~~'.rainbow}
-${'Deploy a new Plasma Chain in just a couple commands.'.white.bold} 🤞😁
+  const rinkebyStep2 = `# On Rinkeby testnet, send your new Operator address ~0.5 ETH.
+  You can use a faucet to get test ETH for free here: ${'https://faucet.rinkeby.io/'.green}`
+  const rinkebyStep3 = `${'$ plasma-chain deploy'.green} # initalizes a new Plasma Chain.
+  Note you will be prompted for a unique Plasma Chain name & IP address.
+  If you are running on your laptop, just set the IP to \`0.0.0.0\` as you probably don't
+  want to reveal your IP to the public. However, if you are running in a data center and would
+  like to accept Plasma transactions & serve a block explorer to the public, go ahead and set an IP.`
+  const customStep2 = '# On your Ethereum node, send your new Operator address ~0.5 ETH'
+  const customStep3 = `${'$ plasma-chain deploy [-n]'.green} # deploys a new Plasma Chain. If you want
+  to also deploy a new Plasma Network Registry, use the \`-n\` flag. Note you will be prompted for a unique
+  Plasma Chain name & IP address (public to the Ethereum chain you deploy to)`
 
-Note that Plasma Chains require a constant connection to the Ethereum network.
-You can set your Ethereum node in your config file located: ${configFile.toString().yellow}
-(All configs & DB files are located in this directory--I promise I won't pollute your home directory!)
-Right now your Web3 HTTP provider is set to: ${config.web3HttpProvider.blue}
+  const introText = `
+  ${'~~~~~~~~~plasma~~~~~~~~~chain~~~~~~~~~operator~~~~~~~~~'.rainbow}
+  ${'Deploy a new Plasma Chain in just a couple commands.'.white.bold} 🤞😁
 
-To deploy a new Plasma Chain, use the following commands:
+  Note that Plasma Chains require a constant connection to the Ethereum network.
+  You can set your Ethereum node in your config file located: ${configFile.toString().yellow}
+  (All configs & DB files are located in this directory--I promise I won't pollute your home directory!)
+  Right now your Web3 HTTP provider is set to: ${config.web3HttpProvider.blue}
 
-1) ${'$ plasma-chain account new'.green}  # create a new account
+  To deploy a new Plasma Chain, use the following commands:
 
-2) ${(isRinkeby) ? rinkebyStep2 : customStep2}
+  1) ${'$ plasma-chain account new'.green}  # create a new account
 
-3) ${(isRinkeby) ? rinkebyStep3 : customStep3}
+  2) ${(isRinkeby) ? rinkebyStep2 : customStep2}
 
-4) ${'$ plasma-chain start'.green} # start your new Plasma Chain
-You can also view your local block explorer at http:127.0.0.1:8000
+  3) ${(isRinkeby) ? rinkebyStep3 : customStep3}
 
-[optional]
-5) ${'$ plasma-chain testSwarm'.green} # spam your Plasma Chain with tons of test transactions 😁
-${'WARNING: This is experimental software--use it carefully!'.yellow}
+  4) ${'$ plasma-chain start'.green} # start your new Plasma Chain
+  You can also view your local block explorer at http:127.0.0.1:8000
 
-${'<3'.red}
-`
+  [optional]
+  5) ${'$ plasma-chain testSwarm'.green} # spam your Plasma Chain with tons of test transactions 😁
+  ${'WARNING: This is experimental software--use it carefully!'.yellow}
 
-program
-  .version('0.0.1')
-  .description(introText)
-  .command('init', 'initalize a new plasma chain')
-  .command('start', 'start the operator')
-  .command('testSwarm', 'start a swarm of test nodes')
-  .command('account [cmd]', 'manage accounts')
-  .action((command) => {
-  })
-  .parse(process.argv)
+  ${'<3'.red}
+  `
+
+  program
+    .version('0.0.1')
+    .description(introText)
+    .command('init', 'initalize a new plasma chain')
+    .command('start', 'start the operator')
+    .command('testSwarm', 'start a swarm of test nodes')
+    .command('account [cmd]', 'manage accounts')
+    .action((command) => {
+    })
+    .parse(process.argv)
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -2,14 +2,16 @@ const fs = require('fs')
 const path = require('path')
 const colors = require('colors') // eslint-disable-line no-unused-vars
 const inquirer = require('inquirer')
-const appRoot = require('app-root-path')
+const { appRootPath } = require('../src/utils');
 const Web3 = require('web3')
 const KEYSTORE_DIR = require('../src/constants.js').KEYSTORE_DIR
 
 const web3 = new Web3()
-const keystoreDirectory = path.join(appRoot.toString(), KEYSTORE_DIR)
 
 async function getAccount () {
+  const appRoot = await appRootPath();
+  const keystoreDirectory = path.join(appRoot, KEYSTORE_DIR)
+
   if (!fs.existsSync(keystoreDirectory)) {
     fs.mkdirSync(keystoreDirectory)
   }
@@ -53,5 +55,6 @@ async function _unlockAccount (encryptedAccount) {
 }
 
 module.exports = {
-  getAccount
+  getAccount,
+  appRootPath,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plasma-chain",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -126,11 +126,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
-    "app-root-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
-      "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo="
     },
     "aproba": {
       "version": "1.2.0",
@@ -3171,12 +3166,14 @@
       "requires": {
         "bn.js": "^4.11.8",
         "ganache-cli": "^6.2.5",
+        "plasma-utils": "^0.0.2",
         "web3": "1.0.0-beta.37"
       },
       "dependencies": {
         "plasma-utils": {
-          "version": "github:plasma-group/plasma-utils#206cadcd96c46e623927baa96704593efd5bcb28",
-          "from": "plasma-utils@github:plasma-group/plasma-utils#206cadcd96c46e623927baa96704593efd5bcb28",
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/plasma-utils/-/plasma-utils-0.0.2.tgz",
+          "integrity": "sha512-1eI/yUiEbNggczs9fPrxMmAVzw/gFe64QJu3FpZ36hMTc0D0aaByAc6OxtS7gdSLGs0hk8HDURe73weqUr+CmQ==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "app-root-path": "^2.1.0",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
     "chai": "^4.2.0",

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -101,7 +101,7 @@ describe('Server api', function () {
   before(async () => {
     // Startup with test config file
     const configFile = path.join(__dirname, 'config-test.json')
-    const config = readConfigFile(configFile, 'test')
+    const config = await readConfigFile(configFile, 'test')
     await server.safeStartup(config)
   })
 

--- a/test/test-block-manager/test-block-store.js
+++ b/test/test-block-manager/test-block-store.js
@@ -52,7 +52,7 @@ describe('BlockStore', function () {
   beforeEach(async () => {
     // Startup with test config file
     const configFile = path.join(__dirname, '..', 'config-test.json')
-    config = readConfigFile(configFile, 'test')
+    config = await readConfigFile(configFile, 'test')
     // Create dbDir and ethDB dir directory
     if (!fs.existsSync(config.dbDir)) {
       log('Creating a new db directory because it does not exist')

--- a/test/test-integration.js
+++ b/test/test-integration.js
@@ -88,7 +88,7 @@ describe('Server', function () {
   before(async () => {
     // Startup with test config file
     const configFile = path.join(__dirname, 'config-test.json')
-    const config = readConfigFile(configFile, 'test')
+    const config = await readConfigFile(configFile, 'test')
     await server.safeStartup(config)
   })
   it('Nodes are able to deposit and send transactions', (done) => {


### PR DESCRIPTION
- Removes dependency `app-root-path`
- Implement new utility to allow for config in the root of the application to be dynamically found
- Update codebase to use new utility

The same 2 tests that were failing are still failing

You can test that each of the commands are working by running the command `npm link` in the root. This will link the program as if it was installed with `npm install -g`. I can also revert the docs to using `npm install -g` if you prefer that over `./bin/...`