### PR TITLE
Make websocket polling do correction related to finality depth

### DIFF
--- a/src/event-watcher.js
+++ b/src/event-watcher.js
@@ -48,7 +48,7 @@ class EventWatcher {
         fromBlock: this.lastLoggedBlock + 1,
         toBlock: block.number - this.finalityDepth
       }, callback)
-      this.lastLoggedBlock = block.number
+      this.lastLoggedBlock = block.number - this.finalityDepth
     })
   }
 }


### PR DESCRIPTION
Without this, there'll be a lot of getPastLogs exceptions when utilizing a WebsocketProvider instead (patches coming later)

Signed-off-by: Carsten Munk <carsten.munk@zippie.org>