### PR TITLE
Extract ethdb logic

### DIFF
--- a/bin/plasma-chain-deploy.js
+++ b/bin/plasma-chain-deploy.js
@@ -1,34 +1,12 @@
 #!/usr/bin/env node
 const path = require('path')
-const fs = require('fs')
 const program = require('commander')
 const colors = require('colors') // eslint-disable-line no-unused-vars
 const inquirer = require('inquirer')
 const getAccount = require('./utils.js').getAccount
 const ethService = require('../src/eth-service.js')
 const readConfigFile = require('../src/utils.js').readConfigFile
-const ETH_DB_FILENAME = require('../src/constants.js').ETH_DB_FILENAME
-
-function loadEthDB (config) {
-  const ethDBPath = path.join(config.ethDBDir, ETH_DB_FILENAME)
-  let ethDB = {}
-  if (fs.existsSync(ethDBPath)) {
-    // Load the db if it exists
-    ethDB = JSON.parse(fs.readFileSync(ethDBPath, 'utf8'))
-  }
-  if (config.plasmaRegistryAddress !== undefined) {
-    ethDB.plasmaRegistryAddress = config.plasmaRegistryAddress
-  }
-  return ethDB
-}
-
-function writeEthDB (config, ethDB) {
-  if (!fs.existsSync(config.dbDir)) {
-    fs.mkdirSync(config.dbDir, { recursive: true })
-    fs.mkdirSync(config.ethDBDir)
-  }
-  fs.writeFileSync(path.join(config.ethDBDir, ETH_DB_FILENAME), JSON.stringify(ethDB))
-}
+const { loadEthDB, writeEthDB } = require('../src/eth-db.js')
 
 program
   .description('starts the operator using the first account')

--- a/src/eth-db.js
+++ b/src/eth-db.js
@@ -17,10 +17,9 @@ function loadEthDB (config) {
 }
 
 function writeEthDB (config, ethDB) {
-  if (!fs.existsSync(config.dbDir)) {
-    log('Creating a new db directory because it does not exist')
-    fs.mkdirSync(config.dbDir, { recursive: true })
-    fs.mkdirSync(config.ethDBDir)
+  if (!fs.existsSync(config.ethDBDir)) {
+    log('Creating a new eth db directory because it does not exist')
+    fs.mkdirSync(config.ethDBDir, { recursive: true })
   }
   fs.writeFileSync(path.join(config.ethDBDir, ETH_DB_FILENAME), JSON.stringify(ethDB))
 }

--- a/src/eth-db.js
+++ b/src/eth-db.js
@@ -1,0 +1,31 @@
+const path = require('path')
+const fs = require('fs')
+const ETH_DB_FILENAME = require('./constants.js').ETH_DB_FILENAME
+const log = require('debug')('info:eth-db')
+
+function loadEthDB (config) {
+  const ethDBPath = path.join(config.ethDBDir, ETH_DB_FILENAME)
+  let ethDB = {}
+  if (fs.existsSync(ethDBPath)) {
+    // Load the db if it exists
+    ethDB = JSON.parse(fs.readFileSync(ethDBPath, 'utf8'))
+  }
+  if (config.plasmaRegistryAddress !== undefined) {
+    ethDB.plasmaRegistryAddress = config.plasmaRegistryAddress
+  }
+  return ethDB
+}
+
+function writeEthDB (config, ethDB) {
+  if (!fs.existsSync(config.dbDir)) {
+    log('Creating a new db directory because it does not exist')
+    fs.mkdirSync(config.dbDir, { recursive: true })
+    fs.mkdirSync(config.ethDBDir)
+  }
+  fs.writeFileSync(path.join(config.ethDBDir, ETH_DB_FILENAME), JSON.stringify(ethDB))
+}
+
+module.exports = {
+  loadEthDB,
+  writeEthDB
+}

--- a/src/eth-service.js
+++ b/src/eth-service.js
@@ -1,5 +1,3 @@
-const path = require('path')
-const fs = require('fs')
 const colors = require('colors') // eslint-disable-line no-unused-vars
 const plasmaChainCompiled = require('plasma-contracts').plasmaChainCompiled
 const plasmaRegistryCompiled = require('plasma-contracts').plasmaRegistryCompiled
@@ -7,8 +5,8 @@ const serializerCompiled = require('plasma-contracts').serializerCompiled
 const Web3 = require('web3')
 const ganache = require('ganache-cli')
 const log = require('debug')('info:eth')
-const ETH_DB_FILENAME = require('./constants.js').ETH_DB_FILENAME
 const EventWatcher = require('./event-watcher.js')
+const { loadEthDB, writeEthDB } = require('./eth-db.js')
 
 const DEPLOY_REGISTRY = 'DEPLOY'
 
@@ -56,28 +54,6 @@ function _getEventWatchers (config) {
     eventWatchers[ethEvent] = new EventWatcher(es.web3, es.plasmaChain, ethEvent, config.finalityDepth, config.ethPollInterval)
   }
   return eventWatchers
-}
-
-function loadEthDB (config) {
-  const ethDBPath = path.join(config.ethDBDir, ETH_DB_FILENAME)
-  let ethDB = {}
-  if (fs.existsSync(ethDBPath)) {
-    // Load the db if it exists
-    ethDB = JSON.parse(fs.readFileSync(ethDBPath, 'utf8'))
-  }
-  if (config.plasmaRegistryAddress !== undefined) {
-    ethDB.plasmaRegistryAddress = config.plasmaRegistryAddress
-  }
-  return ethDB
-}
-
-function writeEthDB (config, ethDB) {
-  if (!fs.existsSync(config.dbDir)) {
-    log('Creating a new db directory because it does not exist')
-    fs.mkdirSync(config.dbDir, { recursive: true })
-    fs.mkdirSync(config.ethDBDir)
-  }
-  fs.writeFileSync(path.join(config.ethDBDir, ETH_DB_FILENAME), JSON.stringify(ethDB))
 }
 
 function initializeWallet (web3, privateKey) {

--- a/src/server.js
+++ b/src/server.js
@@ -101,7 +101,6 @@ async function startup (config) {
   if (!fs.existsSync(config.dbDir)) {
     log('Creating a new db directory because it does not exist')
     fs.mkdirSync(config.dbDir, { recursive: true })
-    fs.mkdirSync(config.ethDBDir)
   }
   try {
     // Setup web3

--- a/test/test-block-manager/test-block-store.js
+++ b/test/test-block-manager/test-block-store.js
@@ -57,7 +57,6 @@ describe('BlockStore', function () {
     if (!fs.existsSync(config.dbDir)) {
       log('Creating a new db directory because it does not exist')
       fs.mkdirSync(config.dbDir)
-      fs.mkdirSync(config.ethDBDir)
       fs.mkdirSync(config.txLogDir)
     }
     // Copy a sample tx log to the dbDir


### PR DESCRIPTION
When I tried to run the operator in Docker I ran into the problem that the `dbDir` directory was already created (due to it being a mounted volume), but the `ethDBDir` wasn't. This let to an error, because the `writeEthDB` method only checks for the existence of the `dbDir` and assumes the `ehtDBDir` to exist.

I also noticed the `readEthDB` and `writeEthDB` code was duplicated and already build to cope with the non-existence of the directory, so I extracted the code in to its own file and removed the unnecessary initialization in two locations.

This change will allow easier implementation of Docker support (https://github.com/plasma-group/plasma-chain-operator/issues/14), which I started working on over here: https://github.com/cryptobias/plasma-chain-operator/tree/docker-support

I unfortunately was not able to execute the tests successfully (even on master). There is no CI for this repository either, is there?