### PR TITLE
introduce basic docker-support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!./bin
+!./src
+!./config.json
+!./index.js
+!./package.json
+!./package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:10-alpine
+
+RUN apk --no-cache add python2 git make g++
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY ./package.json /app
+COPY ./package-lock.json /app
+RUN npm install
+
+COPY . /app
+
+VOLUME [ "/app/operator-keystore", "/app/operator-db" ]
+
+EXPOSE 3000
+
+ENTRYPOINT [ "node", "bin/plasma-chain.js" ]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ $ plasma-chain testSwarm # spam your Plasma Chain with tons of test transactions
 
 ### To open your port, you may need to forward traffic from port 80 to port 3000
 See: https://coderwall.com/p/plejka/forward-port-80-to-port-3000
+
+## Docker Setup
+It is also possible to run the operator in Docker via `docker-compose`.
+
+To run the operator in Docker you will (for now) need to checkout the source, so you can build the container yourself.
+
+To build the container execute `docker-compose build`.
+
+After that the steps are same as described in _Setup_ above (starting from step 1) with `plasma-chain` replaced by `docker-compose run --rm --service-ports operator`.
+
+side note: Since the current setup requires you to enter your passphrase via the commandline and has multiple steps to it, it
+is not possible to simply run `docker-compose up`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  operator:
+    build: .
+    volumes:
+      - keystore:/app/operator-keystore
+      - db:/app/operator-db
+      - ./config.json:/app/config.json
+    ports:
+      - 3000:3000
+
+volumes:
+  keystore:
+  db:


### PR DESCRIPTION
this will mainly allow to use docker locally without having to set up
npm and required dependencies

To properly support running the operator in Docker it would be great if the configuration could get passed in via environment variables. Additionally another means to pass in the passphrase would be needed, I could imagine to either also pass it in via environment variable or starting the operator in a locked mode and unlocking it via an API call.

This PR could resolve https://github.com/plasma-group/plasma-chain-operator/issues/14

It also requires the fix included in https://github.com/plasma-group/plasma-chain-operator/pull/35 