### PR TITLE
Fixed #37 : Added gasPrice as a configuration param

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   "finalityDepth": "1",
   "blockTimeInSeconds": "30",
   "ethPollInterval": "3000",
-  "web3HttpProvider": "https://rinkeby.infura.io/v3/fce31f1fb2d54caa9b31ed7d28437fa5"
+  "web3HttpProvider": "https://rinkeby.infura.io/v3/fce31f1fb2d54caa9b31ed7d28437fa5",
+  "gasPrice":"5000000000"
 }


### PR DESCRIPTION
Implements #37 . I made a big change to the way `eth-service.js` deals with configuration in order to allow for this. Instead of a config object passed between functions on each invocation, it is kept as a global variable only once on `startup()` and then accessed by other functions from the global scope. This allows `submitRootHash()`, the only function not directly/indirectly called by `startup()`, to also access `config.gasPrice`.