### PR TITLE
Added db kill command

### DIFF
--- a/bin/plasma-chain-db.js
+++ b/bin/plasma-chain-db.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+const program = require('commander')
+const fs = require('fs');
+const path = require('path');
+const colors = require('colors') // eslint-disable-line no-unused-vars
+const readConfigFile = require('../src/utils.js').readConfigFile
+const configFile = (process.env.CONFIG) ? process.env.CONFIG : path.join(__dirname, '..', 'config.json')
+const config = readConfigFile(configFile)
+program
+  .command('kill')
+  .description('Destroy operator database contents (dangerous)')
+  .action(async () => {
+    if (!fs.existsSync(config.dbDir)) {
+      console.error("Operator database does not exist. Exiting.".red)
+    } else {
+        try{
+            rimraf(config.dbDir)
+            console.log("Operator database successfully deleted".green)
+        } catch(e) {
+            console.log("Error deleting databse:".red, e)
+        }
+        process.exit()
+    }
+  })
+
+program.parse(process.argv)
+
+if (program.args.length === 1) {
+console.log('Command not found. Try `' + 'operator help db'.yellow + '` for more options')
+}
+
+function rimraf(dir_path) {
+    fs.readdirSync(dir_path).forEach(function(entry) {
+        var entry_path = path.join(dir_path, entry);
+        if (fs.lstatSync(entry_path).isDirectory()) {
+            rimraf(entry_path);
+        } else {
+            fs.unlinkSync(entry_path);
+        }
+    });
+    fs.rmdirSync(dir_path);
+}

--- a/bin/plasma-chain.js
+++ b/bin/plasma-chain.js
@@ -54,6 +54,7 @@ program
   .command('deploy', 'deploy a new plasma chain')
   .command('start', 'start the operator')
   .command('account [cmd]', 'manage accounts')
+  .command('db [cmd]', 'manage local database')
   .command('testSwarm', 'start a swarm of test nodes')
   .command('list', 'list all Plasma Chains on the Registry')
   .action((command) => {


### PR DESCRIPTION
Added `plasma-chain db kill` command to reset operator db. Mostly useful for development and maybe production.